### PR TITLE
Add Prow job to build image from dockerfile

### DIFF
--- a/config/jobs/build-images/build.yaml
+++ b/config/jobs/build-images/build.yaml
@@ -1,0 +1,58 @@
+postsubmits:
+  vagator/test-infra:
+  - name: build-test-image
+    decorate: true
+    run_if_changed: "images/test/.*"
+    branches:
+    - ^main$
+    spec:
+      containers:
+      - name: docker-build
+        image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:20.10.12-dind
+        command:
+        - ./scripts/ci-docker-build-image.sh
+        args:
+        - ./images/dind-go-kubectl
+        securityContext:
+          privileged: true
+        env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+        volumeMounts:
+        - name: dind-storage
+          mountPath: /var/lib/docker
+      volumes:
+      - name: dind-storage
+        emptyDir: {}
+
+periodics:
+- name: build-test-image
+  decorate: true
+  interval: 24h
+  extra_refs:
+  - org: vagator
+    repo: test-infra
+    base_ref: main
+  spec:
+    containers:
+    - name: docker-build
+      image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:20.10.12-dind
+      command:
+      - ./scripts/ci-docker-build-image.sh
+      args:
+      - ./images/dind-go-kubectl
+      securityContext:
+        privileged: true
+      env:
+      - name: DOCKER_TLS_CERTDIR
+        value: ""
+      - name: DOCKER_HOST
+        value: tcp://localhost:2375
+      volumeMounts:
+      - name: dind-storage
+        mountPath: /var/lib/docker
+    volumes:
+    - name: dind-storage
+      emptyDir: {}

--- a/images/dind-go-kubectl/Dockerfile
+++ b/images/dind-go-kubectl/Dockerfile
@@ -1,0 +1,12 @@
+FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:20.10.12-dind
+
+RUN apk add --no-cache \
+    curl \
+    jq \
+    go
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256" && \
+    echo "$(<kubectl.sha256)  kubectl" | sha256sum --check && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl

--- a/scripts/ci-docker-build-image.sh
+++ b/scripts/ci-docker-build-image.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -eux
+
+main() {
+  local dockerfile_path
+  dockerfile_path="${1}"
+
+  # Start Docker
+  dockerd-entrypoint.sh &
+
+  # Docker takes a few seconds to initialize
+  while (! docker stats --no-stream > /dev/null 2>&1 ); do
+    sleep 1
+  done
+
+  # Build docker image...
+  cd "${dockerfile_path}"
+  docker build .
+  local docker_build_exitcode
+  docker_build_exitcode="${?}"
+
+  # Stop Docker background job
+  kill %1
+
+  # Exit with exit code of docker build
+  exit ${docker_build_exitcode}
+}
+
+main ${@}


### PR DESCRIPTION
Add a Prow build image job to build images from dockerfiles. The Prow job has both a postsubmit job and a periodic (24h) job to build the docker image. It does not currently push the image anywhere (this will need to be done later).

Add dind-go-kubectl image Dockerfile. Primarily consists of Docker, Go, and kubectl. Intented to be used by E2E tests, although that hasn't be attempted (may need iterating on once we try to use the image). The dind-go-kubectl image uses docker:20.10.12-dind as the base image, which is based on alpine. Not sure if this will be an issue. If it is we will probably have to use a different base image and replicate with the dind image does.