### PR TITLE
Remove dockerhub proxy references

### DIFF
--- a/config/jobs/build-images/build.yaml
+++ b/config/jobs/build-images/build.yaml
@@ -8,7 +8,7 @@ postsubmits:
     spec:
       containers:
       - name: docker-build
-        image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:20.10.12-dind
+        image: docker:20.10.12-dind
         command:
         - ./scripts/ci-docker-build-image.sh
         args:
@@ -38,7 +38,7 @@ periodics:
   spec:
     containers:
     - name: docker-build
-      image: harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:20.10.12-dind
+      image: docker:20.10.12-dind
       command:
       - ./scripts/ci-docker-build-image.sh
       args:

--- a/images/dind-go-kubectl/Dockerfile
+++ b/images/dind-go-kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/docker:20.10.12-dind
+FROM docker:20.10.12-dind
 
 RUN apk add --no-cache \
     curl \


### PR DESCRIPTION
According to [this job run](https://prow.rajaskakodkar.dev/view/gs/vagator-prow/logs/build-test-image/1485669906639753216) it could not access `harbor-repo.vmware.com/dockerhub-proxy-cache`. This PR changes it to use upstream Dockerhub instead.