### PR TITLE
Add AWS creds back to get around token expiration

### DIFF
--- a/images/image-builder/Dockerfile
+++ b/images/image-builder/Dockerfile
@@ -25,6 +25,11 @@ RUN apt-get update && \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip -q awscliv2.zip && \
+  ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+
 # Move Docker's storage location
 RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
     tee --append /etc/default/docker

--- a/images/image-builder/run.sh
+++ b/images/image-builder/run.sh
@@ -49,8 +49,10 @@ if [[ "${REGISTRY_ENABLED}" == "true" ]]; then
   echo "Registry is enabled, building and pushing image to ${registry_path}"
   export REGISTRY_USERNAME=${REGISTRY_USERNAME:-false}
   export REGISTRY_PASSWORD=${REGISTRY_PASSWORD:-false}
+  export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-false}
+  export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-false}
   # Login into registry
-  docker login --username $(cat ${REGISTRY_USERNAME}) --password $(cat ${REGISTRY_PASSWORD}) public.ecr.aws || { error "Failed to login to ECR"; exit 1; }
+  aws ecr-public get-login | docker login --username $(cat ${REGISTRY_USERNAME}) --password-stdin public.ecr.aws || { error "Failed to login to ECR"; exit 1; }
   # Build image
   cd "${dockerfile_path}"
   docker build -t "${registry_path}" . || { error "Failed to build image in ${registry_path}"; exit 1; }


### PR DESCRIPTION
Signed-off-by: Rajas Kakodkar <rkakodkar@vmware.com>

Authentication token for AWS public ECR is valid for 12 hours so we need to generate it in run.sh before login