### PR TITLE
move tce-bosks test job to test-jobs build cluster

### DIFF
--- a/config/jobs/tce/periodics.yaml
+++ b/config/jobs/tce/periodics.yaml
@@ -23,6 +23,7 @@ periodics:
       securityContext:
         privileged: true
 - name: periodic-build-tce-with-boskos-test
+  cluster: test-jobs
   decorate: true
   cron: 0/5 * * * *
   extra_refs:


### PR DESCRIPTION
Fixing failing job: https://prow.rajaskakodkar.dev/view/gs/vagator-prow/logs/periodic-build-tce-with-boskos-test/1502202725427843072